### PR TITLE
More robust generate_code solution

### DIFF
--- a/PandasBasketball/pandasbasketball.py
+++ b/PandasBasketball/pandasbasketball.py
@@ -1,19 +1,35 @@
 import requests
 from bs4 import BeautifulSoup
+import unidecode
 
 from PandasBasketball.stats import player_stats, team_stats, player_gamelog, n_days
-from PandasBasketball.errors import StatusCode404, TableNonExistent 
+from PandasBasketball.errors import StatusCode404, TableNonExistent
 
 BASE_URL = "https://www.basketball-reference.com"
+POSITIONS = {'PG': 'G', 'SG': 'G', 'SF': 'F', 'PF': 'F', 'C': 'C'}
 
 def generate_code(player):
-    first, last = player.split(" ")
-    
-    first = first[:2]
-    last = last[:5]
-    
-    return (last + first + "01").lower()
+    """
+    Returns a string of a player's basketball-reference code.
+    \tKeyword arguments:
+    \t\tplayer -- the player's name (spelled as it's found on basketball-reference)
+    """
 
+    last_initial = player.split(" ")[1][0].lower()
+    
+    # navigate to https://www.basketball-reference.com/players/{last_initial}/ to scrape the player's href
+    r = requests.get("https://www.basketball-reference.com/players/" + last_initial + "/")
+
+    # parse HTML to find correct href
+    soup = BeautifulSoup(r.text, 'html.parser')
+    player_list = soup.find('tbody').find_all('tr')
+
+    for p in player_list:
+        if unidecode.unidecode(p.find('a').text).lower() == player.lower(): # remove accent mark from player's name if it has any
+            return p.find('a').get('href').split('/')[3].replace('.html', '')
+    
+    # raise an exception if the player's code can't be found
+    raise Exception("Could not find player's basketball-reference code. You may have misspelled their name.")
 
 def get_player(player, stat, numeric=False, s_index=False):
     """
@@ -83,6 +99,3 @@ def get_n_days(days, player="all"):
         url = BASE_URL + f"/friv/last_n_days.fcgi?n={days}"
         r = requests.get(url)
         return n_days(r, days, player=player)
-
-
-    

--- a/PandasBasketball/pandasbasketball.py
+++ b/PandasBasketball/pandasbasketball.py
@@ -6,7 +6,6 @@ from PandasBasketball.stats import player_stats, team_stats, player_gamelog, n_d
 from PandasBasketball.errors import StatusCode404, TableNonExistent
 
 BASE_URL = "https://www.basketball-reference.com"
-POSITIONS = {'PG': 'G', 'SG': 'G', 'SF': 'F', 'PF': 'F', 'C': 'C'}
 
 def generate_code(player):
     """

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Baskteball-reference uses a special code to build each player's unique html page
 **Note:** this is not fully tested, so it is possible to get an incorrect code.
 
 ### Example
-To get the player code for LeBronJames:
+To get the player code for LeBron James:
 ```
 pb.generate_code("LeBron James")
 ```
@@ -123,6 +123,12 @@ Using it with other functions:
 ```
 df = pb.get_player(pb.generate_code("Donovan Mitchell"), "per_game")
 ```
+
+This function is **not** case-sensitive or accent-sensitive. For example, you can retrieve Nikola Jokić's player code with the following:
+```
+pb.generate_code("nikola jokic")
+```
+This will output `'jokicni01'`
 
 
 # Future


### PR DESCRIPTION
Before, the generate_code() function relied on the following format:

{last_name_first_five} + {first_name_first_two} + 01

For example, LeBron James's code is `'jamesle01'`.

However, some players have similar names, which leads to player code collisions. E.g.:

[Max Morris](https://www.basketball-reference.com/players/m/morrima01.html): `'morrima01'`
[Markieff Morris](https://www.basketball-reference.com/players/m/morrima02.html): `'morrima02'`
[Marcus Morris](https://www.basketball-reference.com/players/m/morrima03.html): `'morrima03'`

My solution avoids such collisions by searching through a list of players on basketball-reference based on the player's last name (which can be found [here](https://www.basketball-reference.com/players/m/), in the case above) and finding the correct match. **Note**: My solution does not account for players who have the exact same name, such as [Chris Johnson](https://www.basketball-reference.com/players/j/johnsch04.html) and [Chris Johnson](https://www.basketball-reference.com/players/j/johnsch03.html). However, these cases are few and far between and do not occur with any players of note.

Please let me know if you have any questions or would like for me to do any extra work! (e.g. tests, which I would have done, but I do not see a tests folder in your repo)

